### PR TITLE
chore(release): bump changelog to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+---
+
+## [0.3.0 - 2026-03-08]
+
 ### Added
 - **Skills / graphistry-rest-api**: Added explicit admin healthcheck coverage (`/healthcheck/`, `/ht/`, `healthz`, service health routes), REST vs Python/GFQL boundary guidance, and advanced iframe URL API patterns (`showCollections`, collections global colors).
 - **Skills / REST references**: Added validated REST docs reference pack under `.agents/skills/graphistry-rest-api/references/` with:


### PR DESCRIPTION
## Summary
- cut a new changelog release section `0.3.0` dated `2026-03-08`
- leave `[Development]` empty for subsequent unreleased entries

## Why
- prepares a clean semantic version bump after merged REST skill expansion and harness hardening

## Scope
- docs-only change in `CHANGELOG.md`
