### PR TITLE
docs: add internal release guide and release skill

### DIFF
--- a/.agents/skills/internal/benchmarks/SKILL.md
+++ b/.agents/skills/internal/benchmarks/SKILL.md
@@ -108,3 +108,4 @@ git push origin vX.Y.Z
 ## Related Skills
 - `eval-otel`: OTel trace validation and inspection
 - `plan`: Multi-session task planning (for complex benchmark campaigns)
+- `release`: Semver bump + changelog + tag + GitHub release workflow

--- a/.agents/skills/internal/release/SKILL.md
+++ b/.agents/skills/internal/release/SKILL.md
@@ -65,11 +65,17 @@ git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-### 7) Publish GitHub release
+### 7) Clean up release branch
+```bash
+git branch -d release/vX.Y.Z
+git push origin --delete release/vX.Y.Z
+```
+
+### 8) Publish GitHub release
 ```bash
 gh release create vX.Y.Z \
   --title "vX.Y.Z" \
-  --notes-file /tmp/release_vX.Y.Z.md
+  --generate-notes
 ```
 
 ## Guardrails

--- a/.agents/skills/internal/release/SKILL.md
+++ b/.agents/skills/internal/release/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: release
+description: Internal maintainer skill for cutting graphistry-skills releases (changelog bump, PR merge, semver tag, and GitHub release publish).
+metadata:
+  internal: true
+---
+
+# Release Skill (Internal Maintainer)
+
+Use this for release operations on this repository. This is not a user-facing Graphistry domain skill.
+
+## Use This Skill For
+
+- Cutting a new version from `CHANGELOG.md` `[Development]`
+- Creating the release PR (`release/vX.Y.Z` -> `main`)
+- Tagging the merged release on `main`
+- Publishing a GitHub Release
+
+## Preconditions
+
+- Working tree is clean (`git status --short`)
+- You are in repo root
+- GitHub CLI is authenticated (`gh auth status`)
+
+## Workflow
+
+### 1) Preflight
+```bash
+git fetch origin
+git checkout main
+git pull --ff-only
+python3 scripts/ci/validate_skills.py
+```
+
+### 2) Cut release branch
+```bash
+git checkout -b release/vX.Y.Z
+```
+
+### 3) Update changelog
+- Move all `[Development]` entries into `## [X.Y.Z - YYYY-MM-DD]`.
+- Keep `[Development]` header and comment in place for future entries.
+
+### 4) Commit and push
+```bash
+git add CHANGELOG.md
+git commit -m "chore(release): bump changelog to X.Y.Z"
+git push -u origin release/vX.Y.Z
+```
+
+### 5) Open release PR
+```bash
+gh pr create \
+  --base main \
+  --head release/vX.Y.Z \
+  --title "chore(release): bump changelog to X.Y.Z"
+```
+
+### 6) Merge and tag
+After PR merge:
+```bash
+git checkout main
+git pull --ff-only
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+### 7) Publish GitHub release
+```bash
+gh release create vX.Y.Z \
+  --title "vX.Y.Z" \
+  --notes-file /tmp/release_vX.Y.Z.md
+```
+
+## Guardrails
+
+- Do not release from an unmerged feature branch.
+- Do not tag before the release PR is merged to `main`.
+- Do not put secrets or raw eval artifacts in release notes.
+
+## Related Files
+
+- `RELEASE.md`
+- `CHANGELOG.md`
+- `.agents/skills/internal/benchmarks/SKILL.md`

--- a/.agents/skills/internal/release/SKILL.md
+++ b/.agents/skills/internal/release/SKILL.md
@@ -26,10 +26,9 @@ Use this for release operations on this repository. This is not a user-facing Gr
 
 ### 1) Preflight
 ```bash
-git fetch origin
 git checkout main
 git pull --ff-only
-python3 scripts/ci/validate_skills.py
+python3 scripts/ci/validate_release.py --pre
 ```
 
 ### 2) Cut release branch
@@ -78,14 +77,21 @@ gh release create vX.Y.Z \
   --generate-notes
 ```
 
+### 9) Post-release verification
+```bash
+python3 scripts/ci/validate_release.py --post vX.Y.Z
+```
+
 ## Guardrails
 
 - Do not release from an unmerged feature branch.
 - Do not tag before the release PR is merged to `main`.
 - Do not put secrets or raw eval artifacts in release notes.
+- Run `validate_release.py --pr` during PR review to catch common mistakes.
 
 ## Related Files
 
 - `RELEASE.md`
 - `CHANGELOG.md`
+- `scripts/ci/validate_release.py`
 - `.agents/skills/internal/benchmarks/SKILL.md`

--- a/.agents/skills/internal/release/SKILL.md
+++ b/.agents/skills/internal/release/SKILL.md
@@ -16,70 +16,14 @@ Use this for release operations on this repository. This is not a user-facing Gr
 - Tagging the merged release on `main`
 - Publishing a GitHub Release
 
-## Preconditions
-
-- Working tree is clean (`git status --short`)
-- You are in repo root
-- GitHub CLI is authenticated (`gh auth status`)
-
 ## Workflow
 
-### 1) Preflight
-```bash
-git checkout main
-git pull --ff-only
-python3 scripts/ci/validate_release.py --pre
-```
+Follow `RELEASE.md` in the repo root. Key commands:
 
-### 2) Cut release branch
 ```bash
-git checkout -b release/vX.Y.Z
-```
-
-### 3) Update changelog
-- Move all `[Development]` entries into `## [X.Y.Z - YYYY-MM-DD]`.
-- Keep `[Development]` header and comment in place for future entries.
-
-### 4) Commit and push
-```bash
-git add CHANGELOG.md
-git commit -m "chore(release): bump changelog to X.Y.Z"
-git push -u origin release/vX.Y.Z
-```
-
-### 5) Open release PR
-```bash
-gh pr create \
-  --base main \
-  --head release/vX.Y.Z \
-  --title "chore(release): bump changelog to X.Y.Z"
-```
-
-### 6) Merge and tag
-After PR merge:
-```bash
-git checkout main
-git pull --ff-only
-git tag -a vX.Y.Z -m "Release vX.Y.Z"
-git push origin vX.Y.Z
-```
-
-### 7) Clean up release branch
-```bash
-git branch -d release/vX.Y.Z
-git push origin --delete release/vX.Y.Z
-```
-
-### 8) Publish GitHub release
-```bash
-gh release create vX.Y.Z \
-  --title "vX.Y.Z" \
-  --generate-notes
-```
-
-### 9) Post-release verification
-```bash
-python3 scripts/ci/validate_release.py --post vX.Y.Z
+python3 scripts/ci/validate_release.py --pre           # 1. preflight
+python3 scripts/ci/validate_release.py --pr            # during PR review
+python3 scripts/ci/validate_release.py --post vX.Y.Z   # after release
 ```
 
 ## Guardrails
@@ -87,11 +31,10 @@ python3 scripts/ci/validate_release.py --post vX.Y.Z
 - Do not release from an unmerged feature branch.
 - Do not tag before the release PR is merged to `main`.
 - Do not put secrets or raw eval artifacts in release notes.
-- Run `validate_release.py --pr` during PR review to catch common mistakes.
 
 ## Related Files
 
-- `RELEASE.md`
+- `RELEASE.md` — full step-by-step release guide
+- `scripts/ci/validate_release.py` — automated pre/post/PR checks
 - `CHANGELOG.md`
-- `scripts/ci/validate_release.py`
 - `.agents/skills/internal/benchmarks/SKILL.md`

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -20,6 +20,7 @@ Optional (for OTel trace capture + inspection):
 - Runner: `bin/agent.sh`
 - Core eval engine: `scripts/agent_eval_loop.py`
 - Checked-in benchmark artifacts (public-safe): `benchmarks/data/*/combined_metrics.json` and `benchmarks/reports/*`
+- Release workflow (maintainers): `RELEASE.md`
 
 ## Skill Scope Conventions
 
@@ -334,3 +335,10 @@ python3 scripts/benchmarks/readme_snippet.py \
 5. Update `README.md` Evals section with the generated snippet.
 6. Update `benchmarks/README.md` with the new pack reference.
 7. Check in sanitized report, `combined_metrics.json`, and README updates.
+
+## Releasing Versions
+
+For semver bump + publish steps (release branch, changelog cut, PR merge, tag, GitHub release), use:
+
+- `RELEASE.md` (maintainer release guide)
+- `.agents/skills/internal/release/SKILL.md` (internal release skill)

--- a/README.md
+++ b/README.md
@@ -135,4 +135,5 @@ See:
 - [Report generator](scripts/benchmarks/make_report.py)
 - [Scenario coverage audit tool](scripts/benchmarks/scenario_coverage_audit.py)
 - [Benchmark artifact structure](benchmarks/README.md)
+- [Release guide (maintainers)](RELEASE.md)
 - [Latest eval sweep plan](plans/fresh-eval-sweep-2026-02-28/plan.md)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,89 @@
+# Release Guide (Maintainers)
+
+This document defines the standard release process for `graphistry-skills`.
+
+## Scope
+
+- This repository is consumed from GitHub (for example via `npx skills add graphistry/graphistry-skills`).
+- "Publish" means:
+1. release changes merged to `main`,
+2. semver tag created and pushed,
+3. GitHub Release published with notes.
+
+## Versioning
+
+Use semver `vX.Y.Z`.
+
+- Patch (`Z`): fixes, docs corrections, small harness updates
+- Minor (`Y`): new skills/journeys, meaningful capability expansion
+- Major (`X`): breaking format/workflow changes
+
+## Preflight Checklist
+
+- Local checkout is clean: `git status --short`
+- Local `main` is up to date: `git fetch origin && git checkout main && git pull --ff-only`
+- `CHANGELOG.md` has complete entries under `[Development]`
+- Skills validation passes:
+```bash
+python3 scripts/ci/validate_skills.py
+```
+
+## Standard Release Workflow
+
+1. Create release branch from latest `main`
+```bash
+git checkout main
+git pull --ff-only
+git checkout -b release/vX.Y.Z
+```
+
+2. Cut changelog version section
+- Move current `[Development]` entries under a new heading:
+  - `## [X.Y.Z - YYYY-MM-DD]`
+- Leave `[Development]` empty for future work.
+
+3. Commit and push
+```bash
+git add CHANGELOG.md
+git commit -m "chore(release): bump changelog to X.Y.Z"
+git push -u origin release/vX.Y.Z
+```
+
+4. Open and merge release PR
+- Base: `main`
+- Head: `release/vX.Y.Z`
+- Use squash merge after review/approval policy is satisfied.
+
+5. Tag from updated `main`
+```bash
+git checkout main
+git pull --ff-only
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+6. Publish GitHub Release
+```bash
+gh release create vX.Y.Z \
+  --title "vX.Y.Z" \
+  --notes-file /tmp/release_vX.Y.Z.md
+```
+
+## Post-Release Verification
+
+```bash
+git tag --list --sort=v:refname | tail -n 5
+gh release view vX.Y.Z --json url,publishedAt,tagName,targetCommitish
+```
+
+Verify:
+- tag exists on remote,
+- release is published (not draft),
+- target commit is `main`.
+
+## Related Maintainer Docs
+
+- `CHANGELOG.md`
+- `DEVELOP.md`
+- `.agents/skills/internal/benchmarks/SKILL.md`
+- `.agents/skills/internal/release/SKILL.md`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,13 +20,12 @@ Use semver `vX.Y.Z`.
 
 ## Preflight Checklist
 
-- Local checkout is clean: `git status --short`
-- Local `main` is up to date: `git fetch origin && git checkout main && git pull --ff-only`
-- `CHANGELOG.md` has complete entries under `[Development]`
-- Skills validation passes:
+Run the automated preflight check:
 ```bash
-python3 scripts/ci/validate_skills.py
+python3 scripts/ci/validate_release.py --pre
 ```
+
+This verifies: clean working tree, up-to-date with origin, changelog has content, skills validate, no direct-to-main pushes since last tag.
 
 ## Standard Release Workflow
 
@@ -79,14 +78,19 @@ gh release create vX.Y.Z \
 ## Post-Release Verification
 
 ```bash
-git tag --list --sort=v:refname | tail -n 5
-gh release view vX.Y.Z --json url,publishedAt,tagName,targetCommitish
+python3 scripts/ci/validate_release.py --post vX.Y.Z
 ```
 
-Verify:
-- tag exists on remote,
-- release is published (not draft),
-- target commit is `main`.
+This verifies: tag exists locally and on remote, changelog version section exists, [Development] is empty, release branch cleaned up.
+
+## PR Review Check
+
+During PR review, run:
+```bash
+python3 scripts/ci/validate_release.py --pr
+```
+
+This verifies: branch up-to-date with main, skills validate, eval JSONs valid, no common mistakes (os.environ[], chain()).
 
 ## Related Maintainer Docs
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -62,11 +62,18 @@ git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-6. Publish GitHub Release
+6. Clean up release branch
+```bash
+git branch -d release/vX.Y.Z
+git push origin --delete release/vX.Y.Z
+```
+
+7. Publish GitHub Release
+Generate notes from the changelog section, then publish:
 ```bash
 gh release create vX.Y.Z \
   --title "vX.Y.Z" \
-  --notes-file /tmp/release_vX.Y.Z.md
+  --generate-notes
 ```
 
 ## Post-Release Verification

--- a/scripts/ci/validate_release.py
+++ b/scripts/ci/validate_release.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Validate release preconditions and post-release state.
+
+Usage:
+  python3 scripts/ci/validate_release.py --pre          # before cutting release
+  python3 scripts/ci/validate_release.py --post vX.Y.Z  # after release
+  python3 scripts/ci/validate_release.py --pr            # during PR review
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def run(cmd: str, check: bool = False) -> tuple[int, str]:
+    r = subprocess.run(cmd, shell=True, capture_output=True, text=True, cwd=ROOT)
+    return r.returncode, r.stdout.strip()
+
+
+def check_pre() -> list[str]:
+    """Check preconditions before cutting a release."""
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # Clean working tree
+    _, status = run("git status --short")
+    if status:
+        errors.append(f"Working tree not clean:\n{status}")
+
+    # On main
+    _, branch = run("git branch --show-current")
+    if branch != "main":
+        warnings.append(f"Not on main (on '{branch}') — expected for release branch creation")
+
+    # Up to date with origin
+    run("git fetch origin")
+    rc, _ = run("git diff --quiet HEAD origin/main")
+    if rc != 0:
+        _, diff = run("git log --oneline HEAD..origin/main")
+        errors.append(f"Local main is behind origin:\n{diff}")
+
+    # Changelog has [Development] content
+    changelog = (ROOT / "CHANGELOG.md").read_text()
+    dev_match = re.search(r"## \[Development\].*?\n(.*?)(?=\n## \[|\Z)", changelog, re.DOTALL)
+    if dev_match:
+        content = dev_match.group(1).strip()
+        # Strip the HTML comment
+        content = re.sub(r"<!--.*?-->", "", content).strip()
+        if not content:
+            errors.append("CHANGELOG.md [Development] section is empty — nothing to release")
+    else:
+        errors.append("CHANGELOG.md missing [Development] section")
+
+    # Skills validate
+    rc, out = run("python3 scripts/ci/validate_skills.py")
+    if rc != 0:
+        errors.append(f"Skills validation failed:\n{out}")
+
+    # No direct-to-main pushes since last tag
+    _, last_tag = run("git describe --tags --abbrev=0 2>/dev/null")
+    if last_tag:
+        _, commits = run(f"git log --oneline {last_tag}..HEAD --no-merges")
+        non_pr = [l for l in commits.splitlines() if l and "(#" not in l]
+        if non_pr:
+            warnings.append(f"Commits since {last_tag} without PR reference:\n" +
+                          "\n".join(f"  {l}" for l in non_pr))
+
+    for w in warnings:
+        print(f"WARN: {w}")
+    for e in errors:
+        print(f"FAIL: {e}")
+    if not errors:
+        print(f"PRE-RELEASE: OK ({len(warnings)} warnings)")
+    return errors
+
+
+def check_post(version: str) -> list[str]:
+    """Check post-release state."""
+    errors: list[str] = []
+
+    # Tag exists
+    rc, _ = run(f"git tag -l {version}")
+    if rc != 0 or not _:
+        errors.append(f"Tag {version} does not exist locally")
+
+    # Tag on remote
+    rc, _ = run(f"git ls-remote --tags origin {version}")
+    if not _:
+        errors.append(f"Tag {version} not found on remote")
+
+    # Changelog has version section
+    changelog = (ROOT / "CHANGELOG.md").read_text()
+    v_num = version.lstrip("v")
+    if f"## [{v_num}" not in changelog:
+        errors.append(f"CHANGELOG.md missing section for [{v_num}]")
+
+    # [Development] is empty (content was moved to version section)
+    dev_match = re.search(r"## \[Development\].*?\n(.*?)(?=\n## \[|\Z)", changelog, re.DOTALL)
+    if dev_match:
+        content = re.sub(r"<!--.*?-->", "", dev_match.group(1)).strip()
+        if content:
+            errors.append("[Development] section not empty after release — entries should have moved to version section")
+
+    # Release branch cleaned up
+    rc, _ = run(f"git branch -l release/{version}")
+    if _.strip():
+        errors.append(f"Local branch release/{version} still exists — clean it up")
+    rc, _ = run(f"git ls-remote --heads origin release/{version}")
+    if _.strip():
+        errors.append(f"Remote branch release/{version} still exists — clean it up")
+
+    # On main
+    _, branch = run("git branch --show-current")
+    if branch != "main":
+        errors.append(f"Not on main after release (on '{branch}')")
+
+    for e in errors:
+        print(f"FAIL: {e}")
+    if not errors:
+        print(f"POST-RELEASE {version}: OK")
+    return errors
+
+
+def check_pr() -> list[str]:
+    """Check PR health during review."""
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    _, branch = run("git branch --show-current")
+    if branch == "main":
+        errors.append("On main — expected to be on a feature/release branch")
+        return errors
+
+    # Branch up to date with main
+    run("git fetch origin")
+    _, behind = run("git rev-list --count HEAD..origin/main")
+    if behind and int(behind) > 0:
+        errors.append(f"Branch is {behind} commits behind main — rebase or merge")
+
+    # Skills validate
+    rc, out = run("python3 scripts/ci/validate_skills.py")
+    if rc != 0:
+        errors.append(f"Skills validation failed:\n{out}")
+
+    # Eval JSONs are valid
+    import json
+    for f in sorted((ROOT / "evals" / "journeys").glob("*.json")):
+        try:
+            json.loads(f.read_text())
+        except json.JSONDecodeError as e:
+            errors.append(f"Invalid JSON in {f.name}: {e}")
+
+    # Check for common mistakes
+    _, diff = run("git diff origin/main -- . ':!*.jsonl' ':!*.json'")
+    if "os.environ[" in diff and "os.environ.get(" not in diff:
+        warnings.append("New code uses os.environ[] (may crash on missing vars) — prefer os.environ.get()")
+    if ".chain(" in diff:
+        warnings.append("New code references .chain() — this is deprecated, use .gfql()")
+
+    for w in warnings:
+        print(f"WARN: {w}")
+    for e in errors:
+        print(f"FAIL: {e}")
+    if not errors:
+        print(f"PR CHECK ({branch}): OK ({len(warnings)} warnings)")
+    return errors
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    mode = sys.argv[1]
+    if mode == "--pre":
+        errors = check_pre()
+    elif mode == "--post":
+        if len(sys.argv) < 3:
+            print("Usage: --post vX.Y.Z")
+            sys.exit(1)
+        errors = check_post(sys.argv[2])
+    elif mode == "--pr":
+        errors = check_pr()
+    else:
+        print(__doc__)
+        sys.exit(1)
+
+    sys.exit(1 if errors else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a dedicated maintainer release guide: `RELEASE.md`
- add new internal maintainer skill: `.agents/skills/internal/release/SKILL.md`
- cross-link release workflow from `DEVELOP.md`, `README.md`, and internal `benchmarks` skill

## Why
There was no standalone release guide or release-specific internal skill. Release steps were partially embedded in the benchmarks skill, which made discoverability and consistency weaker.

## Validation
- `python3 scripts/ci/validate_skills.py` (passes)

## Scope
- documentation + skill instructions only (no runtime/harness behavior changes)
