### PR TITLE
fix: validate_release.py strips --- separators in Development check

### DIFF
--- a/scripts/ci/validate_release.py
+++ b/scripts/ci/validate_release.py
@@ -101,7 +101,8 @@ def check_post(version: str) -> list[str]:
     # [Development] is empty (content was moved to version section)
     dev_match = re.search(r"## \[Development\].*?\n(.*?)(?=\n## \[|\Z)", changelog, re.DOTALL)
     if dev_match:
-        content = re.sub(r"<!--.*?-->", "", dev_match.group(1)).strip()
+        content = re.sub(r"<!--.*?-->", "", dev_match.group(1))
+        content = re.sub(r"^-{3,}\s*$", "", content, flags=re.MULTILINE).strip()
         if content:
             errors.append("[Development] section not empty after release — entries should have moved to version section")
 


### PR DESCRIPTION
## Summary
- Post-release validator was flagging `---` separator in [Development] section as non-empty content
- Now strips horizontal rules before checking

Caught during v0.4.1 release flow.

## Test plan
- [x] `python3 scripts/ci/validate_release.py --post v0.4.1` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)