### PR TITLE
feat(gfql): add nested let example + scope rules (pygraphistry >= 0.53.7)

### DIFF
--- a/.agents/skills/pygraphistry-gfql/SKILL.md
+++ b/.agents/skills/pygraphistry-gfql/SKILL.md
@@ -120,6 +120,21 @@ result = g.gfql(let({
 ```
 
 ```python
+# Nested let: inner DAGs execute as opaque units for parallel-friendly pipelines
+result = g.gfql(let({
+    'social': let({
+        'people': n({'type': 'person'}),
+        'friends': ref('people', [e_forward({'rel': 'knows'}), n()]),
+    }),
+    'infra': let({
+        'servers': n({'type': 'server'}),
+        'traffic': ref('servers', [e_forward({'rel': 'serves'}), n()]),
+    }),
+    'combined': ref('social', [e_forward(), n()])
+}), output='combined')
+```
+
+```python
 # Let + degree computation + visual encoding
 from graphistry import n, e_forward, let, ref, call
 result = g.gfql(let({
@@ -132,7 +147,11 @@ result = result.get_degrees().encode_point_color('degree', as_continuous=True)
 
 - **Independent bindings** operate on the root graph
 - **ref()** bindings operate on the referenced binding's output
-- **Multi-stage DAGs**: chain refs sequentially — each binding can reference earlier bindings
+- **Nested let** scope rules (requires pygraphistry >= 0.53.7):
+  - Inner bindings do NOT leak to outer scope
+  - Inner bindings CAN read outer bindings (lexical closure)
+  - Sibling nested lets may reuse names without collision
+  - Each nested let is an opaque execution unit (parallel-friendly)
 
 ## Targeted patterns (high signal)
 ```python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+### Changed
+- **Skills / pygraphistry-gfql**: Restored nested let example now that pygraphistry#968 is fixed in v0.53.7. Added scope rules documentation (inner bindings don't leak to outer, inner can read outer via lexical closure, siblings may reuse names).
+
 ---
 
 ## [0.4.1 - 2026-03-22]


### PR DESCRIPTION
## Summary

- pygraphistry#968 landed in v0.53.7 — nested `let()` now works
- Restore nested let example with parallel-friendly pipeline pattern (social + infra pipelines merging)
- Document scope rules: inner bindings don't leak to outer, inner can read outer (lexical closure), sibling lets may reuse names

## What changed

The GFQL skill previously replaced the broken nested let example with flat sequential refs (v0.4.0 polish). Now that the upstream fix landed, we restore the nested pattern alongside the flat one — both are valid, nested is better for explicit parallelism boundaries.

## Test plan

- [x] Verified nested let works on pygraphistry v0.53.7
- [x] `python3 scripts/ci/validate_skills.py` — 12 skills pass
- [x] `let_nested` eval case already expects this pattern — should pass now

🤖 Generated with [Claude Code](https://claude.com/claude-code)