### PR TITLE
fix(harness): close stdin so codex cannot hang a sweep; cross-harness codex results

### DIFF
--- a/.agents/skills/pygraphistry-gfql/SKILL.md
+++ b/.agents/skills/pygraphistry-gfql/SKILL.md
@@ -252,8 +252,11 @@ Three process-level settings live in `graphistry.compute.gfql.lazy`, each resolv
 
 Read the current value with `call_mode()`, `gpu_executor()`, `cpu_streaming()`; pass `None` to a setter to
 reset to env/default. `'polars'` and `'polars-gpu'` are one lazy engine with two collect targets, so the plan
-is built once and collected once — that transfer-once design is what makes GPU pay off, and it is why
-per-op eager collection is a GPU regression (repeated host-to-device copies).
+is built once and collected once. That transfer-once design is what makes GPU pay off:
+
+- **Collect-once avoids repeated host-to-device (H2D) transfers.** Per-op eager collection re-copies the
+  frame to the device on every operation, which benchmarked as a GPU *regression*.
+- The knobs resolve **Python override > env var > default**, read live per collect — not frozen at import.
 
 ### Physical indexes: seeded lookups
 
@@ -361,16 +364,26 @@ Below roughly a few milliseconds of work, engine choice is noise — indexing an
 
 ### Parity-or-decline: do not invent workarounds
 
-Traversal, filter, and row ops under a Polars engine are **parity-or-`NotImplementedError`** — the engine
-never silently falls back to pandas, because a hidden bridge would misreport pandas performance as Polars.
+Traversal, filter, and row ops under a Polars engine are **parity-or-`NotImplementedError`**:
+
+- The engine **never silently falls back** to pandas — a hidden bridge would misreport pandas performance as Polars.
+- An unsupported surface raises **`NotImplementedError`** (not `RuntimeError`, not a warning).
+- If you run a step on `engine='pandas'` instead, **report the engine that actually executed**. Labeling
+  pandas-executed work as `polars` in a dashboard or benchmark is the failure this contract exists to prevent.
 Surfaces that decline today include undirected `min_hops>1`, a direct `hop(min_hops>1)` (use `chain()`/`gfql()`),
 multi-entity `rows(binding_ops=…)`, cross-entity same-path `WHERE`, and exotic expressions
 (CASE/list/map/temporal). When one of these raises, the correct advice is `engine='pandas'` for that step —
 not a hand-rolled conversion presented as a Polars result.
 
-Conversion into an engine follows the repo-wide `validate`/`warn` convention: on a mixed-type object column
-that Arrow cannot represent, `validate='strict'` raises (`NotImplementedError` for polars) and `'autofix'`
-coerces the column to string and warns.
+Conversion into an engine follows the repo-wide `validate`/`warn` convention. On a mixed-type object column
+that Arrow cannot represent:
+
+| `validate` | behavior |
+| --- | --- |
+| `'strict'` | **raises an error** (`NotImplementedError` for polars); the column is left unchanged |
+| `'autofix'` | **coerces the column to string and emits a warning** — data is silently rewritten unless you read the warning |
+
+Use `'strict'` for any job that must never change data without telling you.
 
 ## Remote mode
 ```python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,24 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Evals / pygraphistry_skill_evals_v1**: 32 per-skill capability cases covering routing, auth/ETL, GFQL, visualization, AI, connectors, and REST — ported from the April 2026 skill-evals audit (originally `.agents/skills/*/evals/evals.json`, a parallel format nothing in the repo executed). The original semantic assertions became oracle `rubric` entries and `forbidden_concepts`; deterministic checks anchor only explicit code/API tokens, so run this journey with `--grading hybrid`.
 
 ### Changed
-- **Skills**: Description trigger phrases rewritten across the eight user-facing skills — quoted user phrasings, symbol triggers (`g.plot()`, `.gfql()`, `engine='polars'`), explicit dispatch targets, and proactive-suggestion cues. Original work by Thomas Cook (#23), rebased onto the v0.5.0 engine/index guidance.
+- **Skills / pygraphistry-gfql**: Made three buried facts scannable — the parity-or-`NotImplementedError` contract as a bulleted list (including "report the engine that actually executed"), strict-vs-autofix conversion as a table, and collect-once host-to-device (H2D) as an explicit bullet. No claim changed, only retrievability. This came out of the codex run below, where the model missed facts the skill already stated in prose.
+- **Evals / pygraphistry_gfql_polars_engines_v1**: Relaxed two over-specific deterministic checks that failed correct answers — `to_pandas()` required empty parens (an answer used `to_pandas(use_pyarrow_extension_array=True)`), and the auto-engine case required the literal word "auto" (an answer said "its default Pandas execution engine", which is the same claim).
+- **Skills**: Description trigger phrases rewritten across the eight user-facing skills — quoted user phrasings, symbol triggers (`g.plot()`, `.gfql()`, `engine='polars'`), explicit dispatch targets, and proactive-suggestion cues. Original work by Thomas Cook (#23), rebased onto the v0.5.0 engine/index guidance. Audit findings kept in `docs/skill-evals-audit-2026-04.md`.
+
+### Fixed
+- **Harness / codex.sh, claude.sh**: Close stdin on the CLI invocation (`< /dev/null`). `codex exec` blocks on `"Reading additional input from stdin..."` whenever it inherits a stdin that never reaches EOF — i.e. any background or non-tty caller — so cells burned their entire per-cell timeout and scored empty responses. The same cells complete in 19-26s with stdin closed. The prompt is passed as an argument, so neither CLI needs stdin.
+
+### Removed
+- **Skills / `*/evals/evals.json`**: Removed the per-skill eval format after porting its cases into the journey harness. It duplicated the journey system and had no runner, so those 32 cases had never executed.
+
+---
 
 ### Tests
+- **Cross-harness follow-up on the GFQL Polars pack (2026-07-26, `codex` `gpt-5.6-terra`, medium effort, hybrid grading, sonnet judge, released `graphistry==0.58.0`, 12 cases x skills on/off)**:
+  - `skills=on` **6/12**, `skills=off` **5/12** — **+8.3pp**, 0 harness errors.
+  - **Much weaker than the Claude result on the same journey, and that gap is the point.** Terra's misses were content, not phrasing: it wrote `RuntimeError` where the skill says `NotImplementedError`, omitted the autofix warning, and skipped the collect-once H2D rationale. Making those scannable moved two cases on re-run (`polars_gpu_executor_selection` 0.76 -> 0.93 pass). Skill guidance only one model can extract is under-specified guidance.
+  - **Not comparable** to the Claude rows in the same report: different model and a journey that grew from 7 to 12 cases.
+  - Six cases still fail with skills on under terra; terra keeps substituting `RuntimeError` for strict-mode declines despite the skill stating `NotImplementedError` in both prose and code — a model behavior, not a docs gap.
 - **Per-skill evals pack (2026-07-25, `claude-sonnet-5`, released `graphistry==0.58.0`, 32 cases x skills on/off, hybrid grading)**:
   - `skills=on`: **100% pass (32/32)**, avg score 0.97, avg `18.9s`
   - `skills=off`: **50.0% pass (16/32)**, avg score 0.80, avg `27.8s`
@@ -23,18 +38,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - **Eight expectations were corrected after seeing model output**, each validated against the installed library: `from_neo4j()` does not exist, `umap()` auto-featurizes, networkx ships Louvain natively, `plot_static` is real where the rubric expected `play:0`, `settings(url_params=...)` is the documented iframe path, and several regexes pinned one spelling of an equivalent answer. Both arms improved (`skills=off` 13/32 -> 16/32), and the overfitting risk is disclosed in the report.
   - At 100% skills-on the pack no longer discriminates at the top; it is kept as a regression harness.
   - Data: `benchmarks/data/2026-07-25-per-skill-evals`, report: `benchmarks/reports/2026-07-25-per-skill-evals.md`.
-
-### Removed
-- **Skills / `*/evals/evals.json`**: Removed the per-skill eval format after porting its cases into the journey harness. It duplicated the journey system and had no runner, so those 32 cases had never executed.
-
-### Added
-- **Skills / evals**: Added `evals/evals.json` to all 8 user-facing skills that were missing per-skill evals: `graphistry`, `pygraphistry`, `pygraphistry-ai`, `pygraphistry-connectors`, `pygraphistry-core`, `pygraphistry-gfql`, `pygraphistry-visualization`, `graphistry-rest-api`. Each file includes 3 positive test cases and 1 negative boundary case with assertions.
-
-### Changed
-- **Skills / descriptions**: Updated description frontmatter for all 8 user-facing skills above to include explicit quoted trigger phrases ("Use when asked to..."), secondary trigger patterns ("Also triggers on..."), and proactive suggest clauses - following skill-creator best practices to reduce undertriggering.
-- **Docs**: Added `docs/skill-evals-audit-2026-04.md` with full audit findings, priority matrix, and implementation plan.
-
----
 
 ## [0.5.0 - 2026-07-25]
 

--- a/benchmarks/reports/2026-07-25-gfql-polars-engines.md
+++ b/benchmarks/reports/2026-07-25-gfql-polars-engines.md
@@ -87,3 +87,44 @@ findings below.
   baseline substantively failed was `polars_parity_or_decline_no_fake_fallback` (oracle 0.55 vs 0.94) —
   it agreed to report pandas-executed work as `engine='polars'`. Integrity/judgment content
   differentiates; API-recall content does not, because the baseline reads the installed package.
+
+---
+
+## Cross-harness follow-up (2026-07-26): codex `gpt-5.6-terra`
+
+The pack's outstanding commitment was to re-run on `codex`. Done, on the expanded 12-case journey
+(`gpt-5.6-terra`, `model_reasoning_effort=medium`, hybrid grading, sonnet judge, released
+`graphistry==0.58.0`):
+
+- `skills=on` **6/12**, `skills=off` **5/12** — **+8.3pp**, 0 harness errors.
+
+**This is much weaker than the Claude result on the same journey, and the gap is the finding.** The
+failures were not phrasing: terra substituted `RuntimeError` where the skill states
+`NotImplementedError`, omitted the autofix warning, and skipped the collect-once host-to-device
+rationale — all facts the skill already contained, but buried in prose paragraphs.
+
+Converting three of those into scannable form (a bulleted parity contract, a strict/autofix table, an
+explicit H2D bullet) — changing no claim, only retrievability — moved two cases on re-run:
+`polars_gpu_executor_selection` 0.76 → **0.93 (pass)** and `polars_gpu_and_strict_analytics` to
+**0.92 (pass)**. Claude had tolerated the prose form; terra did not. **Skill guidance that only one model
+can extract is under-specified guidance.**
+
+Still failing with skills on under terra: `hypergraph_polars_engine_refusal`,
+`polars_auto_engine_regression`, `polars_conversion_validate_semantics`,
+`polars_gpu_availability_fallback_ownership`, `polars_parity_or_decline_no_fake_fallback`,
+`polars_strict_call_mode_benchmark_integrity`. Notably terra keeps writing `RuntimeError` for strict-mode
+declines even though the skill states `NotImplementedError` in both prose and its code example — a model
+behavior, not a documentation gap.
+
+**Not comparable to the Claude rows above**: different model (`gpt-5.6-terra` vs Claude default/sonnet)
+and a journey that grew from 7 to 12 cases. Treat these as a separate harness datapoint, not a delta
+against the Claude numbers.
+
+### Two harness bugs found while doing this
+1. **stdin hang (fixed)** — `codex exec` blocks on `"Reading additional input from stdin..."` whenever it
+   inherits a stdin that never reaches EOF, which is any background/non-tty caller. Cells burned their
+   full timeout and scored empty responses; the same cells complete in 19-26s with stdin closed.
+   `bin/harness/codex.sh` and `bin/harness/claude.sh` now redirect `< /dev/null`.
+2. **Never edit a harness script during a live sweep** — patching `codex.sh` mid-run corrupted the
+   in-flight invocation (bash reads scripts incrementally), producing one `Harness did not emit JSON
+   payload` row scored 0.16 despite a correct answer sitting in the raw log. That row was re-run.

--- a/bin/harness/claude.sh
+++ b/bin/harness/claude.sh
@@ -102,7 +102,9 @@ if [[ -n "$MODEL" ]]; then
   CLAUDE_CMD+=(--model "$MODEL")
 fi
 CLAUDE_CMD+=("$FINAL_PROMPT")
-(cd "$WORKDIR" && timeout "$TIMEOUT_S" "${CLAUDE_CMD[@]}") > "$RAW_OUT" 2>&1
+# stdin closed for the same reason as bin/harness/codex.sh: the prompt is an argument, and an
+# inherited stdin that never EOFs can hang the CLI for the full timeout.
+(cd "$WORKDIR" && timeout "$TIMEOUT_S" "${CLAUDE_CMD[@]}" < /dev/null) > "$RAW_OUT" 2>&1
 exit_code=$?
 set -e
 end_ms=$(date +%s%3N)

--- a/bin/harness/codex.sh
+++ b/bin/harness/codex.sh
@@ -114,7 +114,11 @@ if [[ -n "$MODEL" ]]; then
   CODEX_CMD+=(-c "model_reasoning_effort=\"${REASONING_EFFORT}\"")
 fi
 CODEX_CMD+=("$FINAL_PROMPT")
-timeout "$TIMEOUT_S" "${CODEX_CMD[@]}" > "$RAW_OUT" 2>&1
+# stdin must be closed: codex blocks on "Reading additional input from stdin..." when it
+# inherits an open stdin that never reaches EOF (any non-tty/background caller). The prompt is
+# passed as an argument, so codex needs nothing on stdin. Without this a sweep silently burns
+# its full per-cell timeout and scores an empty response.
+timeout "$TIMEOUT_S" "${CODEX_CMD[@]}" < /dev/null > "$RAW_OUT" 2>&1
 exit_code=$?
 set -e
 end_ms=$(date +%s%3N)

--- a/evals/journeys/pygraphistry_gfql_polars_engines_v1.json
+++ b/evals/journeys/pygraphistry_gfql_polars_engines_v1.json
@@ -18,7 +18,7 @@
           "(?i)engine\\s*=\\s*['\"]polars['\"]",
           "(?i)gfql\\(",
           "(?i)MATCH",
-          "(?i)to_pandas\\(\\)",
+          "(?i)to_pandas\\s*\\(",
           "(?i)(auto.*pandas|pandas.*auto|explicit)"
         ],
         "must_not_contain": [
@@ -119,7 +119,7 @@
       "checks": {
         "regex": [
           "(?i)engine\\s*=\\s*['\"]polars['\"]",
-          "(?i)auto",
+          "(?i)\\b(auto|default)\\b",
           "(?i)(resolv|default|select).{0,60}pandas"
         ],
         "must_not_regex": [


### PR DESCRIPTION
## The bug
`codex exec` blocks on `"Reading additional input from stdin..."` whenever it inherits a stdin that never reaches EOF — i.e. **any background or non-tty caller**. Cells burned their entire per-cell timeout (600s) and scored empty responses. With `< /dev/null` the same cells finish in **19–26s**. The prompt is passed as an argument, so neither CLI needs stdin; `claude.sh` gets the same guard.

This silently poisons sweeps: a timed-out cell scores ~0.11 on an empty response and looks like a model failure.

## Cross-harness codex results (the outstanding commitment on the Polars pack)
`gpt-5.6-terra`, medium effort, hybrid grading, sonnet judge, released `graphistry==0.58.0`, 12 cases × on/off:

- `skills=on` **6/12**, `skills=off` **5/12** — **+8.3pp**, 0 harness errors

**Much weaker than Claude on the same journey, and that gap is the finding.** Terra's misses were content, not phrasing: `RuntimeError` where the skill says `NotImplementedError`, no autofix warning, no collect-once H2D rationale — all facts the skill already contained, buried in prose paragraphs.

Making three of them scannable (bulleted parity contract, strict/autofix table, explicit H2D bullet — **no claim changed**) moved two cases on re-run: `polars_gpu_executor_selection` 0.76 → **0.93 pass**, `polars_gpu_and_strict_analytics` → **0.92 pass**. Claude tolerated the prose; terra did not. **Guidance only one model can extract is under-specified guidance.**

Six cases still fail under terra with skills on; it keeps writing `RuntimeError` for strict-mode declines despite the skill stating `NotImplementedError` in both prose and code — model behavior, not a docs gap. Numbers are **not comparable** to the Claude rows (different model, and the journey grew 7 → 12 cases).

## Also
- Relaxed two deterministic checks that failed correct answers: `to_pandas()` required *empty* parens (an answer used `to_pandas(use_pyarrow_extension_array=True)`), and the auto-engine case required the literal word "auto" where the answer said "its default Pandas execution engine".
- Consolidated duplicate `[Development]` changelog sections, which had inherited contradictory entries from #23 (both "added `evals/evals.json` to 8 skills" and "removed the per-skill eval format").

## A process note worth recording
One row scored 0.16 with a correct answer sitting in its raw log. Cause: I patched `codex.sh` **during** a live sweep, and bash reads scripts incrementally, so the in-flight invocation corrupted and emitted no JSON payload. That row was re-run; the lesson is in the report.

## Validation
- `python3 scripts/ci/validate_skills.py` — 13 OK
- `python3 scripts/ci/validate_release.py --pre` — OK
- `./bin/evals/claude-skills-smoke.sh` — exit 0 after the `claude.sh` change