### PR TITLE
chore(release): bump changelog to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 <!-- Do Not Erase This Section - Used for tracking unreleased changes -->
 
+---
+
+## [0.5.1 - 2026-07-26]
+
 ### Added
 - **Evals / pygraphistry_skill_evals_v1**: 32 per-skill capability cases covering routing, auth/ETL, GFQL, visualization, AI, connectors, and REST — ported from the April 2026 skill-evals audit (originally `.agents/skills/*/evals/evals.json`, a parallel format nothing in the repo executed). The original semantic assertions became oracle `rubric` entries and `forbidden_concepts`; deterministic checks anchor only explicit code/API tokens, so run this journey with `--grading hybrid`.
 


### PR DESCRIPTION
Cut `CHANGELOG.md` `[Development]` into a `v0.5.1` section. No functional changes.

Patch bump per `RELEASE.md`: a harness bug fix, skill-text retrievability improvements, an eval-check correction, and two benchmark packs — no breaking changes and no new skills.

Contents:
- **Fixed**: `codex exec` stdin hang that burned whole per-cell timeouts on empty responses (`< /dev/null` in both harness scripts).
- **Added**: `pygraphistry_skill_evals_v1`, 32 per-skill cases ported from the April audit format that nothing executed.
- **Changed**: skill trigger phrases (Thomas Cook, #23, rebased); three buried GFQL facts made scannable after the codex run showed they weren't being retrieved.
- **Removed**: the dead per-skill `evals/evals.json` format.
- **Tests**: per-skill pack on sonnet (32/32 on vs 16/32 off) and the cross-harness codex follow-up on the Polars pack (6/12 vs 5/12), each with its non-comparability and overfitting caveats stated inline.

Also consolidated duplicate `[Development]` sections that had inherited contradictory entries from #23 — it claimed both "added `evals/evals.json` to 8 skills" and "removed the per-skill eval format".